### PR TITLE
Make custom_interfaces accessible from network_systems CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,10 @@ endif()
 find_package(ament_cmake REQUIRED)
 
 # Add more dependencies manually with: find_package(<dependency> REQUIRED)
-find_package(std_msgs REQUIRED)
-find_package(geometry_msgs REQUIRED)
+set(INTF_DEPENDENCIES std_msgs geometry_msgs)
+foreach(dep IN LISTS INTF_DEPENDENCIES)
+  find_package(${dep} REQUIRED)
+endforeach()
 find_package(rosidl_default_generators REQUIRED)
 
 # Common custom messages
@@ -67,5 +69,7 @@ if(BUILD_TESTING)
   set(ament_cmake_cpplint_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
 endif()
+
+ament_export_dependencies(${INTF_DEPENDENCIES} rosidl_default_runtime)
 
 ament_package()


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Replace _issue_ with the issue number that this PR resolves, or delete the line and add this PR to the Software project if there is no related issue. -->
- Resolves #_issue_
<!-- Describe what was done in this PR if there is no related issue, or the related issue's description is not sufficient. -->


### Verification
<!-- List the steps that were taken to verify that the changes introduced by this PR function as desired and without side effects. -->
- Can build network_systems when including a generated msg header after purging.

### Resources
<!-- Link to any resources that are relevant to this PR. -->
- 
