### PR TITLE
Changed angle bounding with Jay

### DIFF
--- a/msg/HelperHeading.msg
+++ b/msg/HelperHeading.msg
@@ -1,4 +1,4 @@
 # Direction the bow of the boat is pointing towards
 # Unit: degrees, 0° north, increases CW
-# Range: 0 <= heading_degrees < 360
+# Range: -180 < heading_degrees <= 180
 float32 heading

--- a/msg/HelperHeading.msg
+++ b/msg/HelperHeading.msg
@@ -1,4 +1,4 @@
 # Direction the bow of the boat is pointing towards
 # Unit: degrees, 0° north, increases CW
-# Range: -180 < heading_degrees <= 180
+# Range: -180 < heading <= 180
 float32 heading

--- a/msg/WindSensor.msg
+++ b/msg/WindSensor.msg
@@ -1,4 +1,4 @@
 HelperSpeed speed
 # Unit: degrees, 0° means the wind is blowing from the bow to the stern of the boat, increase CW
-# Range: [-180, 180) for symmetry
+# Range: -180 < direction <= 180 for symmetry
 int16 direction


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Replace _issue_ with the issue number that this PR resolves, or delete the line and add this PR to the Software project if there is no related issue. -->

@DFriend01 @hhenry01 @jahn18 Just a heads up about this change to make sure everyone agrees! 

We're hoping that all angles should be bounded in (-180, 180] before they get published in ROS messages. This means anyone using or especially publishing ROS messages with angles. I'll add a topic to tell everyone in the next soft-wide meeting.

<!-- Describe what was done in this PR if there is no related issue, or the related issue's description is not sufficient. -->
- Changed the comments governing the bounding for angles.
- Why was the range (-180, 180] chosen?
     - Symmetry: can easily calculate that 70 degrees is equivalent to -70, instead of 290
     - Matches convention used in python libraries for Jay
     - [math.atan2](https://docs.python.org/3/library/math.html#math.atan2)(0, -1) = *positive* $\pi$ radians, which requires no further bounding under this convention. Note that atan2 takes arguments in the order (opposite, adjacent), so atan2(0, -1) refers to the point (-1, 0) on the negative x-axis.
     - Controls-Sim has done some work assuming -180 to 180 bounding already.

### Verification
<!-- List the steps that were taken to verify that the changes introduced by this PR function as desired and without side effects. -->
- Only changed comments based on discussion in soft-wide meeting today

### Resources
<!-- Link to any resources that are relevant to this PR. -->
- This change was discussed in 2023-10-28 soft-wide [meeting notes](https://ubcsailbot.atlassian.net/wiki/spaces/prjt22/pages/1880227935/2023W1+Software-Wide+Meeting+Notes#:~:text=Standardize%20angle%20bounding)
