### PR TITLE
Changed the HelperROT Type from int to float

### DIFF
--- a/msg/HelperROT.msg
+++ b/msg/HelperROT.msg
@@ -5,4 +5,4 @@
 # -127 and +127 are special values indicates CCW/CW turning of more than 10 degrees/minute (only used if the reporting
 # vessel does not have an external ROT indicator device available)
 # -128 means no rot info
-int8 rot
+float32 rot


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
The HelperROT type should be float rather than int as we are using the message as a float type in the local pathfinding repository.

